### PR TITLE
Use blasfeoConfig.cmake when building with BUILD_WITH_BLASFEO=OFF

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -30,19 +30,7 @@ if (BUILD_WITH_BLASFEO)
     add_subdirectory(blasfeo)
 
 else()
-    set(BLASFEO_INSTALL_DIR "/opt/blasfeo" CACHE PATH "Path to blasfeo installation directory")
-    # find_library(blasfeo NAMES blasfeo PATHS ${BLASFEO_INSTALL_DIR}/lib)
-
-    find_path(BLASFEO_INCLUDE_DIR NAMES "blasfeo.h" PATHS ${BLASFEO_INSTALL_DIR}/include)
-    find_library(BLASFEO_LIBRARY NAMES blasfeo HINTS ${BLASFEO_INSTALL_DIR}/lib)
-
-    # Create an imported static target for blasfeo
-    add_library(blasfeo STATIC IMPORTED GLOBAL)
-    # Set the path to the library file
-    set_target_properties(blasfeo PROPERTIES IMPORTED_LOCATION ${BLASFEO_LIBRARY})
-
-    # Set the path to the include directory
-    set_target_properties(blasfeo PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${BLASFEO_INCLUDE_DIR})
+    find_package(blasfeo REQUIRED)
 
 endif()
 


### PR DESCRIPTION
This PR is meant more as a proposal/discussion rather then a finished PR.

While removing the patch https://github.com/meco-group/fatrop/pull/18 from the conda-forge recipe of fatrop as 0.0.4 release of fatrop was released, I noticed the only remaining patch was this one.

Basically, `blasfeo` when installed installs a `blasfeoConfig.cmake` file, so `find_package` can be used directly instead of manually calling `find_path` and `find_library` and creating an imported target. This works fine in my tests, but if you have any setup with an external blasfeo you want to support, feel free to ask (for example, we could simply add `/opt/blasfeo` to the `PATHS` argument of `find_package` if useful).

fyi @nim65s as he could have an opinion on this based on nix packaging of fatrop.