### PR TITLE
Remove f_out alias for global stream accessor; incompatible with set_stream

### DIFF
--- a/include/fatrop/common/printing.hpp
+++ b/include/fatrop/common/printing.hpp
@@ -45,9 +45,6 @@ namespace fatrop
         bool owns_stream_;
     };
 
-    // Global stream accessor
-    inline std::ostream &f_out = OutputStreamManager::get_stream();
-
     enum class PrintLevel
     {
         None = 0,
@@ -77,7 +74,7 @@ namespace fatrop
         template <typename T> std::ostream &operator<<(const T &value)
         {
             if (global_print_level_ >= this_print_level_)
-                return f_out << value;
+                return OutputStreamManager::get_stream() << value;
             return null_stream_;
         };
 

--- a/include/fatrop/ip_algorithm/ip_linesearch.hxx
+++ b/include/fatrop/ip_algorithm/ip_linesearch.hxx
@@ -335,7 +335,6 @@ namespace fatrop
             }
             if (!accept) // go to restoration phase
             {
-                // f_out << "calling restoration phase" << std::endl;
                 fatrop_assert_msg(restoration_phase_,
                                   "Restoration phase not set in line search object. Maybe called "
                                   "from restoration phase algorithm.");

--- a/legacy/src/OCPCInterface.cpp
+++ b/legacy/src/OCPCInterface.cpp
@@ -622,8 +622,6 @@ namespace fatrop
 
     const FatropOcpCStats *fatrop_ocp_c_get_stats(struct FatropOcpCSolver *s)
     {
-        // todo implement
-        // FatropStats stats_solver = s->driver->app.get_stats();
         FatropOcpCStats *stats = &s->driver->stats;
 
         stats->compute_sd_time = 0.;
@@ -640,10 +638,10 @@ namespace fatrop
         stats->eval_cv_count = 0.;
         stats->eval_grad_count = 0.;
         stats->eval_obj_count = 0.;
-        stats->iterations_count = 0.;
+        stats->iterations_count = s->driver->ip_data->iteration_number();
         stats->return_flag = 0.;
 
-        return &s->driver->stats;
+        return stats;
     }
 
 }

--- a/legacy/src/OCPCInterface.cpp
+++ b/legacy/src/OCPCInterface.cpp
@@ -424,8 +424,8 @@ namespace fatrop
         }
         fatrop_int solve()
         {
-            auto ret = algo->optimize();
-            if (ret == IpSolverReturnFlag::Success)
+            flag = algo->optimize();
+            if (flag == IpSolverReturnFlag::Success)
             {
                 PRINT_ITERATIONS << ip_data->timing_statistics();
                 return 0;
@@ -439,6 +439,7 @@ namespace fatrop
         OptionRegistry options;
         std::shared_ptr<IpAlgorithm<OcpType>> algo;
         std::shared_ptr<IpData<OcpType>> ip_data;
+        IpSolverReturnFlag flag;
     };
 
     FatropOcpCSolver *fatrop_ocp_c_create(FatropOcpCInterface *ocp_interface, FatropOcpCWrite write,
@@ -624,22 +625,22 @@ namespace fatrop
     {
         FatropOcpCStats *stats = &s->driver->stats;
 
-        stats->compute_sd_time = 0.;
+        stats->compute_sd_time = s->driver->ip_data->timing_statistics().compute_search_dir.elapsed();
         stats->duinf_time = 0.;
-        stats->eval_hess_time = 0.;
-        stats->eval_jac_time = 0.;
-        stats->eval_cv_time = 0.;
-        stats->eval_grad_time = 0.;
-        stats->eval_obj_time = 0.;
-        stats->initialization_time = 0.;
-        stats->time_total = 0.;
+        stats->eval_hess_time = s->driver->ip_data->timing_statistics().eval_hessian.elapsed();
+        stats->eval_jac_time = s->driver->ip_data->timing_statistics().eval_jacobian.elapsed();
+        stats->eval_cv_time = s->driver->ip_data->timing_statistics().eval_constraint_violation.elapsed();
+        stats->eval_grad_time = s->driver->ip_data->timing_statistics().eval_gradient.elapsed();
+        stats->eval_obj_time = s->driver->ip_data->timing_statistics().eval_objective.elapsed();
+        stats->initialization_time = s->driver->ip_data->timing_statistics().initialization.elapsed();
+        stats->time_total = s->driver->ip_data->timing_statistics().full_algorithm.elapsed();
         stats->eval_hess_count = 0.;
         stats->eval_jac_count = 0.;
         stats->eval_cv_count = 0.;
         stats->eval_grad_count = 0.;
         stats->eval_obj_count = 0.;
         stats->iterations_count = s->driver->ip_data->iteration_number();
-        stats->return_flag = 0.;
+        stats->return_flag = int(s->driver->flag);
 
         return stats;
     }


### PR DESCRIPTION
Note that set_stream is currently required in the C interface.
An alternative implementation in which the alias could be preserved is to not modify the outputmanager stream in the C interface, but rather initialize it first time right.