### PR TITLE
Fix BLASFEO GEMM alignment in OCP solver

### DIFF
--- a/src/ocp/aug_system_solver.cpp
+++ b/src/ocp/aug_system_solver.cpp
@@ -302,7 +302,7 @@ LinsolReturnFlag AugSystemSolver<OcpType>::solve(const ProblemInfo<OcpType> &inf
                     // ([S^T \\ r^T] L^-T) @ (L^-1 eta^T)
                     // (eta L^-T) @ ([S^T \\ r^T] L^-T)^T
                     gemm_nt(gamma_k - rank_k, nx + 1, nu - rank_k, -1.0, Ggt_stripe[0], 0, 0,
-                            Llt[k], nu - rank_k, 0, 1.0, Hh[k], 0, 0, Hh[k], 0, 0);
+                            Llt_shift[0], 0, 0, 1.0, Hh[k], 0, 0, Hh[k], 0, 0);
                     // keep (L^-1 eta^T) for forward recursion
                     getr(gamma_k - rank_k, nu - rank_k, Ggt_stripe[0], 0, 0, Ggt_tilde[k], 0,
                          rank_k);


### PR DESCRIPTION
## Summary
- Reuses the existing `Llt_shift` temporary for the OCP augmented-system solver's increased-accuracy `gemm_nt` call.
- Avoids passing a row-offset BLASFEO matrix operand to `gemm_nt`, matching the nearby shifted-copy path already used for the Schur complement update.

## Details
Without this change, certain OCP dimensions can send BLASFEO's `gemm_nt` down a path where the B-operand alignment arithmetic reaches outside the matrix buffer. In the source downstream reproducer, this showed up for a 3-control stage with `K = 2`, `nu = {3, 0}`, `nx = {4, 4}`, `ng = {0, 1}`, and `ng_ineq = {0, 0}`. That case keeps the stage-0 rank at zero, so the increased-accuracy Schur update multiplies a 3-row L block through a non-4-aligned B operand.

The invalid read is page-layout sensitive: it may be harmless most of the time, but can crash when the overread crosses a page boundary. This is visible under valgrind: the unpatched code reports invalid reads in `kernel_dgemm_nt_4x4_gen_lib4`, while the same reproducer passes cleanly with this fix. Copying the shifted L block into `Llt_shift` first gives `gemm_nt` an aligned operand while preserving the same numerical operation.

## Testing
- Relevant FATROP unit tests for the OCP augmented-system solver pass locally.
- Downstream valgrind reproducer passes with this fix; removing the patch reports invalid reads in `kernel_dgemm_nt_4x4_gen_lib4`.
- Full local FATROP suite reached 122/124 passing; the remaining two failures were unrelated option registry tests.