### PR TITLE
Remove hardcoded -march=native from CMAKE_CXX_FLAGS_RELEASE 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,7 @@ if(NOT CMAKE_BUILD_TYPE)
     "Debug" "Release")
 endif()
 
-# Set compilation flags for Release and Debug
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG")
+# Set compilation flags for Debug
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 # Option to build tests (default is ON)


### PR DESCRIPTION
## What

Removes the release-flag override in the top-level `CMakeLists.txt`:

```cmake
set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG")
```

## Why

This forces `-march=native` on every Release build (and re-states `-O3 -DNDEBUG`, which CMake's `Release` config already provides for GCC/Clang). A few problems come from that:

* **Breaks cross-compilation:** `-march=native` tunes for the machine doing the build, so cross-compiling fatrop for a different target produces code for the wrong CPU.
* **Silently overrides the consumer:** Because it's a plain `set()` (not a cache variable), it clobbers any `-DCMAKE_CXX_FLAGS_RELEASE=...` or toolchain `CMAKE_CXX_FLAGS_INIT` passed by a downstream build. You can't override it without editing the file.
* **GCC/Clang-only:** `-O3` / `-march=native` aren't valid for MSVC.