### PR TITLE
Add installable CMake package configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
 project(fatrop VERSION 1.0.0 LANGUAGES CXX C)
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -29,11 +32,30 @@ if(FATROP_ENABLE_ASAN)
 endif()
 
 # Define installation directories
-set(LIBRARY_INSTALL_DIR lib)
-set(ARCHIVE_INSTALL_DIR lib)
-set(RUNTIME_INSTALL_DIR bin)
-set(INCLUDE_INSTALL_DIR include)
-set(CMAKE_INSTALL_DIR cmake)
+set(LIBRARY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
+set(ARCHIVE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
+set(RUNTIME_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
+set(CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/fatropConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/fatropConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_DIR}"
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/fatropConfigVersion.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/fatropConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/fatropConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_DIR}"
+)
 
 # Add the external directory
 add_subdirectory(external)

--- a/cmake/fatropConfig.cmake.in
+++ b/cmake/fatropConfig.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(blasfeo CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/fatropTargets.cmake")
+
+check_required_components(fatrop)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,7 +119,7 @@ set(INSTALL_TARGETS fatrop)
 
 # Export the target
 install(TARGETS ${INSTALL_TARGETS}
-    EXPORT fatropConfig
+    EXPORT fatropTargets
     LIBRARY DESTINATION ${LIBRARY_INSTALL_DIR}
     ARCHIVE DESTINATION ${ARCHIVE_INSTALL_DIR}
     RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
@@ -132,6 +132,7 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/fatrop
         FILES_MATCHING PATTERN "*.hpp")
 
 # Install the export
-install(EXPORT fatropConfig
+install(EXPORT fatropTargets
+        FILE fatropTargets.cmake
         NAMESPACE fatrop::
         DESTINATION ${CMAKE_INSTALL_DIR})


### PR DESCRIPTION
## Summary

  Adds proper CMake package support so downstream projects can consume Fatrop with:

  ```
find_package(fatrop CONFIG REQUIRED)
  target_link_libraries(app PRIVATE fatrop::fatrop)
```

  ## Changes

  - Generates and installs fatropConfig.cmake and fatropConfigVersion.cmake.
  - Exports fatrop::fatrop through fatropTargets.cmake.
  - Finds the required BLASFEO dependency for consumers.
  - Uses relocatable package paths.
  - Uses standard GNU installation directories.
  - Installs package files under <libdir>/cmake/fatrop.

  ## Validation

  - Successfully configured and built the fatrop target with bundled BLASFEO.