### PR TITLE
ip_iterate: cache scalar norms used by the optimality error

### DIFF
--- a/include/fatrop/ip_algorithm/ip_iterate.hpp
+++ b/include/fatrop/ip_algorithm/ip_iterate.hpp
@@ -275,6 +275,21 @@ namespace fatrop
         const VecRealView &dual_infeasibility_s();
 
         /**
+         * @brief Cached infinity norm of constr_viol().
+         */
+        Scalar constr_viol_inf();
+
+        /**
+         * @brief Cached infinity norm of dual_infeasibility_x().
+         */
+        Scalar dual_infeasibility_x_inf();
+
+        /**
+         * @brief Cached infinity norm of dual_infeasibility_s().
+         */
+        Scalar dual_infeasibility_s_inf();
+
+        /**
          * @brief Computes and returns the gradient of the barrier function.
          * @return Constant reference to the barrier function gradient.
          */
@@ -556,6 +571,21 @@ namespace fatrop
         bool complementarity_u_evaluated_ =
             false;                              ///< Flag for upper bound complementarity evaluation
         bool primal_damping_evaluated_ = false; ///< Flag for primal damping evaluation
+        bool dual_l1_norms_evaluated_ = false;  ///< Flag for the cached l1 norms of the duals
+
+        // Cached scalar norms of iterate quantities (used by e_mu, which may be
+        // called several times per iteration).  The inf norms are computed
+        // together with their vector inside the accessor, so they share the
+        // corresponding *_evaluated_ flag; the l1 norms of the multipliers have
+        // their own flag which is cleared whenever a dual vector is modified.
+        Scalar constr_viol_inf_ = 0.;          ///< inf norm of constr_viol_
+        Scalar dual_infeasibility_x_inf_ = 0.; ///< inf norm of dual_infeasibility_x_
+        Scalar dual_infeasibility_s_inf_ = 0.; ///< inf norm of dual_infeasibility_s_
+        Scalar dual_bounds_l1_ = 0.;           ///< norm_l1(dual_bounds_l_) + norm_l1(dual_bounds_u_)
+        Scalar dual_eq_l1_ = 0.;               ///< norm_l1(dual_eq_)
+
+        /// Recomputes the cached l1 norms of the multipliers if needed.
+        void update_dual_l1_norms();
 
         Index *number_of_bounds_; ///< Total number of bounds in the problem
         Scalar kappa_d_ = 1e-5;
@@ -601,6 +631,7 @@ void fatrop::IpIterate<ProblemType>::set_dual_eq(const VecReal<Derived> &dual_eq
 {
     dual_infeasibility_s_evaluated_ = false;
     dual_infeasibility_x_evaluated_ = false;
+    dual_l1_norms_evaluated_ = false;
     dual_eq_ = dual_eq;
 }
 template <typename ProblemType>
@@ -609,6 +640,7 @@ void fatrop::IpIterate<ProblemType>::set_dual_bounds_l(const VecReal<Derived> &d
 {
     complementarity_l_evaluated_ = false;
     dual_infeasibility_s_evaluated_ = false;
+    dual_l1_norms_evaluated_ = false;
     dual_bounds_l_ = if_else(lower_bounded(), dual_bounds_l, VecRealScalar(dual_bounds_l_.m(), 0.));
 }
 template <typename ProblemType>
@@ -617,6 +649,7 @@ void fatrop::IpIterate<ProblemType>::set_dual_bounds_u(const VecReal<Derived> &d
 {
     complementarity_u_evaluated_ = false;
     dual_infeasibility_s_evaluated_ = false;
+    dual_l1_norms_evaluated_ = false;
     dual_bounds_u_ = if_else(upper_bounded(), dual_bounds_u, VecRealScalar(dual_bounds_u_.m(), 0.));
 }
 
@@ -627,6 +660,7 @@ void fatrop::IpIterate<ProblemType>::modify_dual_bounds(Scalar mu)
     complementarity_l_evaluated_ = false;
     complementarity_u_evaluated_ = false;
     dual_infeasibility_s_evaluated_ = false;
+    dual_l1_norms_evaluated_ = false;
     dual_bounds_l_ =
         if_else(lower_bounded(),
                 max(min(dual_bounds_l_,

--- a/include/fatrop/ip_algorithm/ip_iterate.hxx
+++ b/include/fatrop/ip_algorithm/ip_iterate.hxx
@@ -41,6 +41,7 @@ namespace fatrop
         complementarity_l_evaluated_ = false;
         complementarity_u_evaluated_ = false;
         primal_damping_evaluated_ = false;
+        dual_l1_norms_evaluated_ = false;
     }
 
     template <typename ProblemType> Scalar IpIterate<ProblemType>::obj_value()
@@ -107,9 +108,16 @@ namespace fatrop
             Index status =
                 nlp_->eval_constraint_violation(info(), primal_x_, primal_s_, constr_viol_);
             fatrop_assert_msg(status == 0, "Error in evaluating the constraint violation.");
+            constr_viol_inf_ = norm_inf(constr_viol_);
             constr_viol_evaluated_ = true;
         }
         return constr_viol_;
+    }
+
+    template <typename ProblemType> Scalar IpIterate<ProblemType>::constr_viol_inf()
+    {
+        constr_viol();
+        return constr_viol_inf_;
     }
     template <typename ProblemType>
     const VecRealView &IpIterate<ProblemType>::dual_infeasibility_x()
@@ -120,9 +128,16 @@ namespace fatrop
             dual_infeasibility_x_.block(dual_infeasibility_x_.m(), 0) = obj_gradient_x();
             jacobian().transpose_apply_on_right(info(), dual_eq_, 1.0, dual_infeasibility_x_,
                                                 dual_infeasibility_x_);
+            dual_infeasibility_x_inf_ = norm_inf(dual_infeasibility_x_);
             dual_infeasibility_x_evaluated_ = true;
         }
         return dual_infeasibility_x_;
+    }
+
+    template <typename ProblemType> Scalar IpIterate<ProblemType>::dual_infeasibility_x_inf()
+    {
+        dual_infeasibility_x();
+        return dual_infeasibility_x_inf_;
     }
 
     template <typename ProblemType>
@@ -136,9 +151,26 @@ namespace fatrop
             dual_infeasibility_s_ = obj_gradient_s() + dual_bounds_u_ - dual_bounds_l_;
             nlp_->apply_jacobian_s_transpose(info(), dual_eq_, 1.0, dual_infeasibility_s_,
                                              dual_infeasibility_s_);
+            dual_infeasibility_s_inf_ = norm_inf(dual_infeasibility_s_);
             dual_infeasibility_s_evaluated_ = true;
         }
         return dual_infeasibility_s_;
+    }
+
+    template <typename ProblemType> Scalar IpIterate<ProblemType>::dual_infeasibility_s_inf()
+    {
+        dual_infeasibility_s();
+        return dual_infeasibility_s_inf_;
+    }
+
+    template <typename ProblemType> void IpIterate<ProblemType>::update_dual_l1_norms()
+    {
+        if (!dual_l1_norms_evaluated_)
+        {
+            dual_bounds_l1_ = norm_l1(dual_bounds_l_) + norm_l1(dual_bounds_u_);
+            dual_eq_l1_ = norm_l1(dual_eq_);
+            dual_l1_norms_evaluated_ = true;
+        }
     }
 
     template <typename ProblemType> const VecRealView &IpIterate<ProblemType>::barrier_gradient()
@@ -279,14 +311,15 @@ namespace fatrop
     template <typename ProblemType> Scalar IpIterate<ProblemType>::e_mu(Scalar mu)
     {
         ScopedTimer _t(timings_->compute_e_mu, *timings_);
-        Scalar zl1 = norm_l1(dual_bounds_l()) + norm_l1(dual_bounds_u());
+        update_dual_l1_norms();
+        Scalar zl1 = dual_bounds_l1_;
         Index number_of_eq_constraints = nlp()->nlp_dims().number_of_eq_constraints;
         Index number_of_dual_vars = (*number_of_bounds_) + number_of_eq_constraints;
-        Scalar lam_mean = (zl1 + norm_l1(dual_eq())) / (number_of_dual_vars);
+        Scalar lam_mean = (zl1 + dual_eq_l1_) / (number_of_dual_vars);
         Scalar z_mean = zl1 / (*number_of_bounds_);
-        Scalar constraint_violation = norm_inf(constr_viol());
-        Scalar dual_infeasibility_x_linf = norm_inf(dual_infeasibility_x());
-        Scalar dual_infeasibility_s_linf = norm_inf(dual_infeasibility_s());
+        Scalar constraint_violation = constr_viol_inf();
+        Scalar dual_infeasibility_x_linf = dual_infeasibility_x_inf();
+        Scalar dual_infeasibility_s_linf = dual_infeasibility_s_inf();
         Scalar dual_infeasibility_linf =
             std::max(dual_infeasibility_x_linf, dual_infeasibility_s_linf);
         Scalar complementarity_l_linf = norm_inf(relaxed_complementarity_l(mu));


### PR DESCRIPTION
e_mu() is evaluated several times per IP iteration (convergence checks plus the monotone mu-update loop) and recomputed every norm from scratch on each call, which made it one of the most expensive parts of an iteration (~17% of solve time on a warm-started MPC benchmark).

Cache the scalars instead of recomputing them:
- the inf norms of constr_viol, dual_infeasibility_x and dual_infeasibility_s are computed once, next to their vector, guarded by the existing *_evaluated_ flags (new accessors constr_viol_inf() etc.);
- the l1 norms of the multipliers get their own evaluated flag, invalidated in set_dual_eq, set_dual_bounds_l/u, modify_dual_bounds and reset_evaluated_quantities.

The cached values are bit-identical to the previous computation; iteration counts are unchanged (8580 iterations across 1500 warm-started solves of a quadrotor MPC benchmark) while total solve time drops ~10% (compute_e_mu 102 -> 18 ms).