### PR TITLE
Fuse the relaxed-complementarity norm in IpIterate::e_mu

### DIFF
--- a/include/fatrop/ip_algorithm/ip_iterate.hxx
+++ b/include/fatrop/ip_algorithm/ip_iterate.hxx
@@ -322,11 +322,8 @@ namespace fatrop
         Scalar dual_infeasibility_s_linf = dual_infeasibility_s_inf();
         Scalar dual_infeasibility_linf =
             std::max(dual_infeasibility_x_linf, dual_infeasibility_s_linf);
-        // Fused relaxed-complementarity infinity norm: e_mu is evaluated several times per
-        // iteration (convergence checks and the barrier update loop), and materializing the two
-        // relaxed-complementarity temporaries plus separate norm passes on every call is the
-        // dominant remaining cost here. complementarity_l()/complementarity_u() are cached per
-        // iterate, so each call is two read-only passes.
+        // Compute the norm from cached complementarity vectors to avoid materializing relaxed
+        // temporaries.
         const VecRealView &compl_l = complementarity_l();
         const VecRealView &compl_u = complementarity_u();
         Scalar complementarity_linf = 0.;

--- a/include/fatrop/ip_algorithm/ip_iterate.hxx
+++ b/include/fatrop/ip_algorithm/ip_iterate.hxx
@@ -322,9 +322,24 @@ namespace fatrop
         Scalar dual_infeasibility_s_linf = dual_infeasibility_s_inf();
         Scalar dual_infeasibility_linf =
             std::max(dual_infeasibility_x_linf, dual_infeasibility_s_linf);
-        Scalar complementarity_l_linf = norm_inf(relaxed_complementarity_l(mu));
-        Scalar complementarity_u_linf = norm_inf(relaxed_complementarity_u(mu));
-        Scalar complementarity_linf = std::max(complementarity_l_linf, complementarity_u_linf);
+        // Fused relaxed-complementarity infinity norm: e_mu is evaluated several times per
+        // iteration (convergence checks and the barrier update loop), and materializing the two
+        // relaxed-complementarity temporaries plus separate norm passes on every call is the
+        // dominant remaining cost here. complementarity_l()/complementarity_u() are cached per
+        // iterate, so each call is two read-only passes.
+        const VecRealView &compl_l = complementarity_l();
+        const VecRealView &compl_u = complementarity_u();
+        Scalar complementarity_linf = 0.;
+        for (Index i = 0; i < compl_l.m(); i++)
+        {
+            if ((*lower_bounded_)[i])
+                complementarity_linf = std::max(complementarity_linf, std::abs(compl_l(i) - mu));
+        }
+        for (Index i = 0; i < compl_u.m(); i++)
+        {
+            if ((*upper_bounded_)[i])
+                complementarity_linf = std::max(complementarity_linf, std::abs(compl_u(i) - mu));
+        }
         Scalar res = 0.;
         Scalar sd = 0.;
         Scalar sc = 0.;


### PR DESCRIPTION
## Summary

`IpIterate::e_mu` is evaluated several times per interior-point iteration. Compute the
relaxed-complementarity infinity norm directly from the cached complementarity vectors, avoiding two
temporary writes and their subsequent norm passes. Skipping unbounded entries is equivalent to their
previous zero contribution.

## Measurements

On approximately 10k small OCP solves (nx=4, nu=3, horizons 40-200), reverting this change increased
mean/p99 total solve time by 4.0%/7.9%. Solver outputs and iteration paths were bit-identical.

## Testing

Full CMake build with `WITH_BUILD_BLASFEO=ON`; `ctest` passes 123/125. The same two
`OptionRegistryTest` failures reproduce on pristine `main`.

